### PR TITLE
2417 qr dedicated rabbitmq

### DIFF
--- a/service/src/main/resources/config/bootstrap.yml
+++ b/service/src/main/resources/config/bootstrap.yml
@@ -17,6 +17,7 @@ spring:
       uri: '${CONFIG_SERVER_URL:http://configuration:8888/configserver}'
     stream:
       rabbit:
+        port: 5673
         bindings:
           queryMetricSource-out-0:
             producer:


### PR DESCRIPTION
Create a dedicated rabbitmq for the query results to use. It leaves the existing one in place.